### PR TITLE
Feature: Respect default Resque Wildcard

### DIFF
--- a/lib/resque/plugins/dynamic_queues/queues.rb
+++ b/lib/resque/plugins/dynamic_queues/queues.rb
@@ -19,7 +19,10 @@ module Resque
         def queues_with_dynamic
           queue_names = @queues.dup
 
-          return queues_without_dynamic if queue_names.grep(/(^!)|(^@)|(\*)/).size == 0
+          # Make sure it's a pattern wildcard and not a general wildcard.
+          dynamic_pattern = /(^!)|(^@)|((^\*[a-zA-Z0-9_-]+)|([^\*][a-zA-Z0-9_-]+\*))/
+          
+          return queues_without_dynamic if queue_names.grep(dynamic_pattern).size == 0
 
           real_queues = Resque.queues
           matched_queues = []

--- a/spec/queues_spec.rb
+++ b/spec/queues_spec.rb
@@ -124,6 +124,11 @@ describe "Dynamic Queues" do
       worker.queues.should == ["high_x", "high_y", "superhigh_z"]
     end
 
+    it "can order queues with traditional wildcard use" do
+      worker = Resque::Worker.new("high_x", "high_y", "*", "superhigh_z")
+      worker.queues.should == ["high_x", "high_y", "foo", "superhigh_z"]
+    end
+
     it "can blacklist queues" do
       worker = Resque::Worker.new("*", "!foo")
       worker.queues.should == ["high_x", "high_y", "superhigh_z"]


### PR DESCRIPTION
I noticed this gem was not properly handling Resque's wildcard priority system.  For example, `QUEUE="high,medium,*,superlow` was attempting to read the \* as a wildcard pattern in the vein of `*high` instead of priortizing high, medium, all other queues before superlow, and super low.  I've updated the pattern regex to only match a wildcard before or after a alphanumeric/dash/underscore pattern.  There's also a test for this.
