### PR TITLE
Removes sorting of queues to preserve original order

### DIFF
--- a/lib/resque/plugins/dynamic_queues/queues.rb
+++ b/lib/resque/plugins/dynamic_queues/queues.rb
@@ -54,7 +54,7 @@ module Resque
             end
           end
 
-          return matched_queues.uniq.sort
+          return matched_queues.uniq
         end
 
 


### PR DESCRIPTION
Removes sorting of matched_queues, so that the original order in which the dynamic queue was defined is preserved.
