### PR TITLE
Respect the order in which queues/patterns are defined

### DIFF
--- a/lib/resque/plugins/dynamic_queues/queues.rb
+++ b/lib/resque/plugins/dynamic_queues/queues.rb
@@ -21,7 +21,7 @@ module Resque
 
           return queues_without_dynamic if queue_names.grep(/(^!)|(^@)|(\*)/).size == 0
 
-          real_queues = Resque.queues
+          real_queues = Resque.queues.sort
           matched_queues = []
 
           while q = queue_names.shift
@@ -54,7 +54,7 @@ module Resque
             end
           end
 
-          return matched_queues.uniq.sort
+          return matched_queues.uniq
         end
 
 

--- a/spec/queues_spec.rb
+++ b/spec/queues_spec.rb
@@ -134,6 +134,17 @@ describe "Dynamic Queues" do
       worker.queues.should == ["foo"]
     end
 
+    it "respects the order in which queue patterns are defined" do
+      worker = Resque::Worker.new("h*", "f*")
+      worker.queues.should == ["high_x", "high_y", "foo"]
+
+      worker = Resque::Worker.new("*", "!f*")
+      worker.queues.should == ["high_x", "high_y", "superhigh_z"]
+
+      worker = Resque::Worker.new("*high*_z", "*", "!f*")
+      worker.queues.should == ["superhigh_z", "high_x", "high_y"]
+    end
+
   end
 
   context "redis backed queues" do
@@ -141,7 +152,7 @@ describe "Dynamic Queues" do
     it "can dynamically lookup queues" do
       Resque.set_dynamic_queue("mykey", ["foo", "bar"])
       worker = Resque::Worker.new("@mykey")
-      worker.queues.should == ["bar", "foo"]
+      worker.queues.should == ["foo", "bar"]
     end
 
     it "can blacklist dynamic queues" do
@@ -180,7 +191,7 @@ describe "Dynamic Queues" do
       host = `hostname`.chomp
       Resque.set_dynamic_queue(host, ["foo", "bar"])
       worker = Resque::Worker.new("@")
-      worker.queues.should == ["bar", "foo"]
+      worker.queues.should == ["foo", "bar"]
     end
 
     it "can use wildcards in dynamic queues" do
@@ -197,7 +208,7 @@ describe "Dynamic Queues" do
     it "falls back to default queues when missing" do
       Resque.set_dynamic_queue("default", ["foo", "bar"])
       worker = Resque::Worker.new("@mykey")
-      worker.queues.should == ["bar", "foo"]
+      worker.queues.should == ["foo", "bar"]
     end
 
     it "falls back to all queues when missing and no default" do


### PR DESCRIPTION
The default Resque behavior is to respect the order in which queues are defined. Currently, `resque-dynamic-queues` returns all matched queues sorted alphabetically. This might lead to confusing results.

### Example
Existing queues:
* a_ext_high
* a_ext_medium
* a_ext_low
* a_int_high
* a_int_medium
* a_int_low
* b_int_high
* b_int_medium
* b_int_low

`Resque::Worker.new(a_*_high, a_*_medium, a_*_low").queues`
* Old queue order: `["a_ext_high", "a_ext_low", "a_ext_medium", "a_int_high", "a_int_low", "a_int_medium"]`
* New queue order: `["a_ext_high", "a_int_high", "a_ext_medium", "a_int_medium", "a_ext_low", "a_int_low"]`

Instead of returning matched queues sorted alphabetically, pre-sort all queues and keep the order in which patterns were defined.